### PR TITLE
Support block editing for loras (Hunyuan et al)

### DIFF
--- a/MultiLoraLoader.py
+++ b/MultiLoraLoader.py
@@ -19,17 +19,17 @@ class MultiLoraLoader:
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "model": ("MODEL",),
-                              "clip": ("CLIP", ),
                               "text": ("STRING", {
                                 "multiline": True,
                                 "default": ""}),
-                            }}
+                            },
+                "optional": {"clip": ("CLIP", ),}}
 
     RETURN_TYPES = ("MODEL", "CLIP")
     FUNCTION = "load_loras"
     CATEGORY = "loaders"
 
-    def load_loras(self, model, clip, text):
+    def load_loras(self, model, text, clip = None):
         result = (model, clip)
         
         lora_items = self.selected_loras.updated_lora_items_with_text(text)


### PR DESCRIPTION
Now blocks can be filtered in text loras.

<lora:dog:1.0:double_blocks> will filter in only the double blocks with model and clip weights set to 1.0.
<lora:dog:1.0:0.5:single_blocks> will filter in only the single blocks with model weight at 1.0 and clip weights set to 0.5.

To select only certain block indices, separate individual indices by comma (11, 12) or indicate a range with a hyphen (0-10).

<lora:dog:1.0:double_blocks[0-10, 12, 13]> to include only the numbered double blocks.
<lora:dog:1.0:double_blocks[0-10, 12, 13]:single_blocks[10,15]> to include only the numbered double and single blocks.

Blocks can be indicated in any order and no error will be thrown in the event that a block index does not exist.

Finally, one can indicate "even" or "odd" instead to select every other block in a given block section, like this:

<lora:dog:1.0:double_blocks[even]> to include only even double blocks.
<lora:dog:1.0:single_blocks[odd]> to include only odd single blocks.